### PR TITLE
Session cookie now modifiable in after_action

### DIFF
--- a/spec/response_spec.cr
+++ b/spec/response_spec.cr
@@ -22,6 +22,14 @@ describe "end to end requests and responses" do
       result.headers["Location"].should eq("/other_route")
     end
 
+    it "can modify session cookie data in an after_action" do
+      result = curl("GET", "/bob_jane/modified_session")
+      result.body.should eq("ok")
+      cookie = result.headers["Set-Cookie"]
+      cookie.starts_with?("_test_session_=").should eq(true)
+      cookie.should contain "domain=bobjane.com"
+    end
+
     it "#redirect" do
       cookie = "_test_session_=CKQMLS12oJZBIh3Hlbpg19XGFAphCiRW7NMHq31epbpGTfI9N0T7WeIR1C%2FFDJ%2FW--IEb0qAXKV9DtrLdnyqzdGbBM2ww%3D"
       result = curl("GET", "/bob_jane/redirect", {"Cookie" => cookie})
@@ -150,6 +158,7 @@ describe "end to end requests and responses" do
         {"BobJane", :deep_show, :get, "/bob_jane/params/:id/test/:test_id"},
         {"BobJane", :create, :post, "/bob_jane/post_test"},
         {"BobJane", :update, :put, "/bob_jane/put_test"},
+        {"BobJane", :modified_session, :get, "/bob_jane/modified_session"},
         {"BobJane", :index, :get, "/bob_jane/"},
       ])
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -40,6 +40,7 @@ end
 
 class BobJane < ActionController::Base
   # base "/bob/jane" # <== automatically configured
+  after_action :modify_session, only: :modified_session
 
   # Test default CRUD
   def index
@@ -68,6 +69,15 @@ class BobJane < ActionController::Base
 
   put "/put_test", :update do
     render text: "ok"
+  end
+
+  get "/modified_session", :modified_session do
+    session["hello"] = "setting_session"
+    render text: "ok"
+  end
+
+  private def modify_session
+    response.cookies["_test_session_"].domain = "bobjane.com"
   end
 end
 

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -453,6 +453,10 @@ abstract class ActionController::Base
             end
           {% end %}
 
+          # Check if session needs to be written
+          session = instance.__session__
+          session.encode(context.response.cookies) if session && session.modified
+
           # Execute the after filters
           {% after_actions = AFTER.keys %}
           {% for method, options in AFTER %}
@@ -475,10 +479,6 @@ abstract class ActionController::Base
               {% end %}
             end
           {% end %}
-
-          # Check if session needs to be written
-          session = instance.__session__
-          session.encode(context.response.cookies) if session && session.modified
 
           # Implement error handling
           {% if !RESCUE.empty? %}


### PR DESCRIPTION
Main advantage being that properties of the session cookie can be tweaked to allow for multi-tenanted apps, e.g. domain. Without this, it becomes difficult to set the domain on-the-fly or modify other default properties of the session cookie.

There is a bit of an oddity that I haven't quite been able to solve. The following works:
```crystal
after_action :tweak_session
private def tweak_session
  response.cookies["_spider_gazelle_"].domain = User.organization.cookie_domains # ensure to set from trusted source and not rely on the 'Host' header
end
```

But accessing the bare cookies object doesn't. edit: because the "_spider_gazelle_" cookie isn't available on `cookies`.
```crystal
# ...
cookies["_spider_gazelle_"].domain = User.organization.cookie_domains
```
Intial thought is that it may have been some struct pass-by-value type issue but I couldn't get to the bottom of it.

Let me know if you need any changes.