### PR TITLE
Crystal 0.35: Stringify remote address when processing client IP

### DIFF
--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -702,7 +702,7 @@ abstract class ActionController::Base
         end
       end
 
-      cip = (request.remote_address || "127.0.0.1").split(":")[0] unless cip
+      cip = (request.remote_address.try(&.to_s) || "127.0.0.1").split(":")[0] unless cip
     end
 
     @client_ip = cip


### PR DESCRIPTION
This is for compatibility with Crystal 0.35. See https://github.com/crystal-lang/crystal/pull/9210.

As this appears to only be intended to return the IP address component, I've taken the simple approach of stringifying the remote address, but perhaps you'd also like to return a `Socket::Address` as std now does.

This should be backwards-compatible with 0.34.