### PR TITLE
Log handler

### DIFF
--- a/src/action-controller/log_handler.cr
+++ b/src/action-controller/log_handler.cr
@@ -1,38 +1,88 @@
 require "./logger"
 
-# A handler that logs the request method, resource, status code, and
-# the time used to execute the next handler, to the given `IO`.
 module ActionController
+  # A handler that logs the request method, resource, status code, and the time
+  # taken to execute.
   class LogHandler
     include HTTP::Handler
 
-    # Initializes this handler to log to the given `IO`.
-    def initialize(filter = nil)
-      @filter = filter ? filter.to_a.map(&.to_s) : [] of String
+    # Events that occur within the request lifecycle.
+    @[Flags]
+    enum Event
+      Request
+      Response
+      def self.all
+        Request | Response
+      end
     end
 
-    @filter : Array(String)
+    # Creates a new `LogHandler` for inserting into middlewhere.
+    #
+    # Use *filter* to specified any keys that may appear in request params that
+    # should be redacted prior to passing to the logging backend. This may
+    # include secrets or PII that should not leave the bounds of this system.
+    #
+    # *log* can be used to specify what sections of the request lifecycle to
+    # log. The defaults to the response (either valid or error) only, however
+    # support is also provide for request entry logging for development
+    # environments.
+    def initialize(@filter = [] of String, @log = Event::Response)
+    end
 
-    def call(context)
-      ::Log.context.clear
+    private getter filter
 
-      elapsed = Time.measure { call_next(context) }
+    private getter log
 
+    def call(context : HTTP::Server::Context) : Nil
+      ::Log.with_context do
+        emit_request context if log.request?
+
+        start = Time.monotonic
+        duration = Time::Span::ZERO
+
+        begin
+          begin
+            call_next context
+          ensure
+            duration = Time.monotonic - start
+          end
+          emit_response context, duration if log.response?
+        rescue e
+          emit_error context, duration, e if log.response?
+          raise e
+        end
+      end
+    end
+
+    # Emits an inbound request message for the passed `Context`.
+    private def emit_request(context : HTTP::Server::Context)
       Log.info &.emit(
-        duration: elapsed_text(elapsed),
+        event: "request",
+        method: context.request.method,
+        path: filter_path(context.request.resource)
+      )
+    end
+
+    # Emits a response entry.
+    private def emit_response(context : HTTP::Server::Context, duration : Time::Span)
+      Log.info &.emit(
+        event: "response",
         method: context.request.method,
         path: filter_path(context.request.resource),
-        status: context.response.status_code
+        status: context.response.status_code,
+        duration: elapsed_text(duration)
       )
-    rescue e
+    end
+
+    # Emits an error entry.
+    private def emit_error(context : HTTP::Server::Context, duration : Time::Span, e : Exception)
       Log.error(exception: e, &.emit(
+        event: "error",
         method: context.request.method,
         path: filter_path(context.request.resource),
         status: 500,
-        duration: elapsed_text(elapsed ? elapsed : 0.seconds),
+        duration: elapsed_text(duration)
       ))
-
-      raise e
     end
 
     private def elapsed_text(elapsed)


### PR DESCRIPTION
Adds support for logging of both request and response, in addition to some other minor neaten ups.

I’ve got a few other things to submit this way for improving tracing across multi-service deploys, but this is a precursor for that.