### PR TITLE
fix: Encode session cookie when redirect_to

### DIFF
--- a/spec/response_spec.cr
+++ b/spec/response_spec.cr
@@ -30,6 +30,11 @@ describe "end to end requests and responses" do
       cookie.should contain "domain=bobjane.com"
     end
 
+    it "encode session cookie when redirect_to" do
+      result = curl("GET", "/bob_jane/modified_session_with_redirect")
+      result.headers["Set-Cookie"].should_not be_nil
+    end
+
     it "#redirect" do
       cookie = "_test_session_=CKQMLS12oJZBIh3Hlbpg19XGFAphCiRW7NMHq31epbpGTfI9N0T7WeIR1C%2FFDJ%2FW--IEb0qAXKV9DtrLdnyqzdGbBM2ww%3D"
       result = curl("GET", "/bob_jane/redirect", {"Cookie" => cookie})
@@ -159,6 +164,7 @@ describe "end to end requests and responses" do
         {"BobJane", :create, :post, "/bob_jane/post_test"},
         {"BobJane", :update, :put, "/bob_jane/put_test"},
         {"BobJane", :modified_session, :get, "/bob_jane/modified_session"},
+        {"BobJane", :modified_session_with_redirect, :get, "/bob_jane/modified_session_with_redirect"},
         {"BobJane", :index, :get, "/bob_jane/"},
       ])
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -97,6 +97,11 @@ class BobJane < ActionController::Base
     render text: "ok"
   end
 
+  get "/modified_session_with_redirect", :modified_session_with_redirect do
+    session["user_id"] = 42_i64
+    redirect_to "/"
+  end
+
   private def modify_session
     session.domain = "bobjane.com"
   end

--- a/src/action-controller/responders.cr
+++ b/src/action-controller/responders.cr
@@ -164,6 +164,10 @@ module ActionController::Responders
 
   macro redirect_to(path, status = :found)
     %response = @context.response
+
+    %session = @__session__
+    %session.encode(%response.cookies) if %session && %session.modified
+
     %response.status_code = {{REDIRECTION_CODES[status] || status}}
     %response.headers["Location"] = {{path}}
     @render_called = true


### PR DESCRIPTION
Following the guide https://spider-gazelle.net/#/controllers/overview?id=accessing-the-session,

The session didn't set cookie when using `redirect_to`. 
Fixed by adding the `session.encode` in `redirect_to` macro

