### PR TITLE
feat: allow multiple ways to write less verbose context spec

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: action-controller
-version: 3.4.0
+version: 3.4.1
 
 dependencies:
   # Used in clustering

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -28,9 +28,9 @@ describe "Context" do
     parsed.should contain({name: "James", state: "NSW"})
   end
 
-  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block" do
+  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block but have Controller module included directly" do
     # Instantiate the controller
-    res = Controller(Users).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)
+    res = Users.context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)
 
     # Expectation
     res.status_code.should eq 200

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -12,7 +12,8 @@ describe "Context" do
 
     # Expectation
     ctx.response.status_code.should eq 200
-    parsed = UserRes.from_json(ctx.response.output.to_s)
+    ctx.response.output.rewind
+    parsed = UserRes.from_json(ctx.response.output)
     parsed.size.should eq(5)
     parsed.should contain({name: "James", state: "NSW"})
   end
@@ -23,7 +24,7 @@ describe "Context" do
 
     # Expectation
     res.status_code.should eq 200
-    parsed = UserRes.from_json(res.body)
+    parsed = UserRes.from_json(res.output)
     parsed.size.should eq(5)
     parsed.should contain({name: "James", state: "NSW"})
   end
@@ -34,18 +35,8 @@ describe "Context" do
 
     # Expectation
     res.status_code.should eq 200
-    parsed = UserRes.from_json(res.body)
+    parsed = UserRes.from_json(res.output)
     parsed.size.should eq(5)
     parsed.should contain({name: "James", state: "NSW"})
-  end
-
-  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block, and deserialise output into defined type" do
-    # Instantiate the controller
-    res = ControllerModel(Users, UserRes).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)
-
-    # Expectation
-    res.status_code.should eq 200
-    res.body.size.should eq(5)
-    res.body.as(UserRes).should contain({name: "James", state: "NSW"})
   end
 end

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -1,0 +1,51 @@
+BASE = Users.base_route
+alias UserRes = Array(NamedTuple(name: String, state: String))
+
+describe "Context" do
+  it "should spec #index the most verbose way" do
+    # Instantiate the controller
+    body_io = IO::Memory.new
+    ctx = context("GET", BASE, body: body_io, authorization: "X")
+    ctx.route_params = {"verbose" => "true"}
+    ctx.response.output = IO::Memory.new
+    Users.new(ctx).index
+
+    # Expectation
+    ctx.response.status_code.should eq 200
+    parsed = UserRes.from_json(ctx.response.output.to_s)
+    parsed.size.should eq(5)
+    parsed.should contain({name: "James", state: "NSW"})
+  end
+
+  it "should spec #index without specifying body, output IO::Memory" do
+    # Instantiate the controller
+    res = context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}) { |i| Users.new(i).index }
+
+    # Expectation
+    res.status_code.should eq 200
+    parsed = UserRes.from_json(res.body)
+    parsed.size.should eq(5)
+    parsed.should contain({name: "James", state: "NSW"})
+  end
+
+  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block" do
+    # Instantiate the controller
+    res = Controller(Users).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)
+
+    # Expectation
+    res.status_code.should eq 200
+    parsed = UserRes.from_json(res.body)
+    parsed.size.should eq(5)
+    parsed.should contain({name: "James", state: "NSW"})
+  end
+
+  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block, and deserialise output into defined type" do
+    # Instantiate the controller
+    res = ControllerModel(Users, UserRes).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)
+
+    # Expectation
+    res.status_code.should eq 200
+    res.body.size.should eq(5)
+    res.body.as(UserRes).should contain({name: "James", state: "NSW"})
+  end
+end

--- a/spec/curl_context.cr
+++ b/spec/curl_context.cr
@@ -132,3 +132,7 @@ module ActionController::Context
     end
   end
 end
+
+abstract class ActionController::Base
+  include ActionController::Context
+end

--- a/spec/curl_context.cr
+++ b/spec/curl_context.cr
@@ -1,3 +1,4 @@
+# # Spec route by setting up HTTP::Client
 def curl(method : String, path : String, headers = {} of String => String, body : HTTP::Client::BodyType = nil) : HTTP::Client::Response
   client = HTTP::Client.new "localhost", 6000
 
@@ -29,25 +30,6 @@ def curl(method : String, path : String, headers = {} of String => String, body 
   client.close
 
   response.not_nil!
-end
-
-# Creates a context for specing controllers
-def context(
-  method : String,
-  path : String,
-  headers : HTTP::Headers? = nil,
-  body : String | Bytes | IO | Nil = nil,
-  version = "HTTP/1.1",
-  response_io = IO::Memory.new,
-  **header_opts
-)
-  headers ||= HTTP::Headers.new
-  header_opts.each do |key, value|
-    headers.add(key.to_s.split(/-|_/).map(&.capitalize).join("-"), value.to_s)
-  end
-  response = HTTP::Server::Response.new(response_io, version)
-  request = HTTP::Request.new(method, path, headers, body, version)
-  HTTP::Server::Context.new request, response
 end
 
 ::CURL_CONTEXT__ = [] of ActionController::Server
@@ -85,4 +67,92 @@ macro with_server(&block)
   {% end %}
 
   {{block.body}}
+end
+
+# # Creates a context for specing controllers
+
+# Use context by manually instantiating the entire context with IO::Memory in body and output
+def context(
+  method : String,
+  path : String,
+  headers : HTTP::Headers? = nil,
+  body : String | Bytes | IO | Nil = nil,
+  version = "HTTP/1.1",
+  response_io = IO::Memory.new,
+  **header_opts
+)
+  headers ||= HTTP::Headers.new
+  header_opts.each do |key, value|
+    headers.add(key.to_s.split(/-|_/).map(&.capitalize).join("-"), value.to_s)
+  end
+  response = HTTP::Server::Response.new(response_io, version)
+  request = HTTP::Request.new(method, path, headers, body, version)
+  HTTP::Server::Context.new request, response
+end
+
+# Helper to instantiate context
+private def instantiate_context(method : String, route : String, route_params : Hash(String, String)? = nil, headers : Hash(String, String)? = nil, body : JSON::Any? = nil)
+  headers_io = HTTP::Headers.new
+
+  if !headers.nil?
+    headers.each do |key, value|
+      headers_io.add(key, value)
+    end
+  end
+
+  body_io = body.nil? ? IO::Memory.new : IO::Memory.new(body)
+  ctx = context(method, route, headers: headers_io, body: body_io)
+  ctx.route_params = route_params unless route_params.nil?
+  ctx.response.output = IO::Memory.new
+
+  ctx
+end
+
+record ContextResponse, status_code : Int32, body : String, object : HTTP::Server::Response
+
+# Use context by instantiating the context without specifying body, output IO::Memory
+def context(method : String, route : String, route_params : Hash(String, String)? = nil, headers : Hash(String, String)? = nil, body : JSON::Any? = nil, &block)
+  ctx = instantiate_context(method, route, route_params, headers, body)
+  yield ctx
+  res = ctx.response.not_nil!
+
+  ContextResponse.new(res.status_code, res.output.to_s, res)
+end
+
+# Use context by instantiating the context without specifying body, output IO::Memory, instantiating controller in each block
+module Controller(T)
+  extend self
+
+  def context(method : String, route : String, route_params : Hash(String, String)? = nil, headers : Hash(String, String)? = nil, body : JSON::Any? = nil, &block)
+    ctx = instantiate_context(method, route, route_params, headers, body)
+    instance = T.new(ctx)
+    yield instance
+    res = ctx.response.not_nil!
+
+    ContextResponse.new(res.status_code, res.output.to_s, res)
+  end
+end
+
+record DeserialisedContextResponse(M), status_code : Int32, body : M, object : HTTP::Server::Response
+
+# Use context by instantiating the context without specifying body, output IO::Memory, instantiating controller in each block, and deserialise output into defined type
+module ControllerModel(T, M)
+  extend self
+
+  def context(method : String, route : String, route_params : Hash(String, String)? = nil, headers : Hash(String, String)? = nil, body : JSON::Any? = nil, &block)
+    ctx = instantiate_context(method, route, route_params, headers, body)
+    instance = T.new(ctx)
+    yield instance
+    res = ctx.response.not_nil!
+
+    if M == JSON::Any
+      body = JSON.parse(res.output.to_s)
+      DeserialisedContextResponse(JSON::Any).new(res.status_code, body, res)
+    elsif M == Nil
+      raise ArgumentError.new("Cannot serialise into Nil")
+    else
+      body = M.from_json(res.output.to_s).not_nil!
+      DeserialisedContextResponse(M).new(res.status_code, body, res)
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -108,6 +108,20 @@ abstract class Application < ActionController::Base
   end
 end
 
+class Users < ActionController::Base
+  base "/users"
+
+  def index
+    head :unauthorized if request.headers["Authorization"]? != "X"
+
+    if params["verbose"] = "true"
+      render json: [{name: "James", state: "NSW"}, {name: "Pavel", state: "VIC"}, {name: "Steve", state: "NSW"}, {name: "Gab", state: "QLD"}, {name: "Giraffe", state: "NSW"}]
+    else
+      render json: ["James", "Pavel", "Steve", "Gab", "Giraffe"]
+    end
+  end
+end
+
 class HelloWorld < Application
   base "/hello"
 

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -4,9 +4,11 @@ require "./responders"
 require "./session"
 require "./support"
 require "uri"
+require "../../spec/curl_context"
 
 abstract class ActionController::Base
   include ActionController::Responders
+  include ActionController::Context
 
   # Route IDs params
   DEFAULT_PARAM_ID = {} of Nil => Nil

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -8,7 +8,6 @@ require "../../spec/curl_context"
 
 abstract class ActionController::Base
   include ActionController::Responders
-  include ActionController::Context
 
   # Route IDs params
   DEFAULT_PARAM_ID = {} of Nil => Nil


### PR DESCRIPTION
This PR allows for multiple ways to write less verbose context specs

For example, with the following controller (all sample codes below available in `/spec/`)

```crystal
class Users < ActionController::Base
  base "/users"

  def index
    head :unauthorized if request.headers["Authorization"]? != "X"

    if params["verbose"] = "true"
      render json: [{name: "James", state: "NSW"}, {name: "Pavel", state: "VIC"}, {name: "Steve", state: "NSW"}, {name: "Gab", state: "QLD"}, {name: "Giraffe", state: "NSW"}]
    else
      render json: ["James", "Pavel", "Steve", "Gab", "Giraffe"]
    end
  end
end
```

Helpers are:
```crystal
# Helpers
BASE = Users.base_route
alias UserRes = Array(NamedTuple(name: String, state: String))
```

The usual way to write this with context is

```crystal
  it "should spec #index the most verbose way" do
    # Instantiate the controller
    body_io = IO::Memory.new
    ctx = context("GET", BASE, body: body_io, authorization: "X")
    ctx.route_params = {"verbose" => "true"}
    ctx.response.output = IO::Memory.new
    Users.new(ctx).index

    # Expectation
    ctx.response.status_code.should eq 200
    parsed = UserRes.from_json(ctx.response.output.to_s)
    parsed.size.should eq(5)
    parsed.should contain({name: "James", state: "NSW"})
  end
```

However, there is a few templating and hence repetitive code if this format is written over and over again, specifically

```crystal
body_io = IO::Memory.new
ctx.response.output = IO::Memory.new
Users.new(ctx).index
parsed = UserRes.from_json(ctx.response.output.to_s)
```

The above code can be re-written with the updated `context()` as

```crystal
it "should spec #index without specifying body, output IO::Memory" do
    # Instantiate the controller
    res = context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}) { |i| Users.new(i).index }

    # Expectation
    res.status_code.should eq 200
    parsed = UserRes.from_json(res.body)
    parsed.size.should eq(5)
    parsed.should contain({name: "James", state: "NSW"})
  end
```

This should only be used if one would like to override `initialize` and specify additional params other than just the context, e.g. `Users.new(context)`, because one can write this without the `Controller.new(context)` as

```crystal
  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block" do
    # Instantiate the controller
    res = Controller(Users).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)

    # Expectation
    res.status_code.should eq 200
    parsed = UserRes.from_json(res.body)
    parsed.size.should eq(5)
    parsed.should contain({name: "James", state: "NSW"})
  end
```

The above however still returns the serialised as JSON, we can do this directly in the generic type declaration as

```crystal
  it "should spec #index without specifying body, output IO::Memory, instantiating controller in each block, and deserialise output into defined type" do
    # Instantiate the controller
    res = ControllerModel(Users, UserRes).context(method: "GET", route: BASE, route_params: {"verbose" => "true"}, headers: {"Authorization" => "X"}, &.index)

    # Expectation
    res.status_code.should eq 200
    res.body.size.should eq(5)
    res.body.as(UserRes).should contain({name: "James", state: "NSW"})
  end
```