### PR TITLE
fix(base): ensure filters are run in the order of definition

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: action-controller
-version: 3.5.1
+version: 4.0.0
 
 dependencies:
   # Used in clustering

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -38,4 +38,9 @@ describe ActionController::Base do
       HelloWorld.show
     end
   end
+
+  it "should execute filters in the order they were defined" do
+    result = curl("GET", "/filtering")
+    result.body.should eq("ok")
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,9 +4,45 @@ require "xml"
 require "log"
 require "../src/action-controller"
 
+abstract class FilterOrdering < ActionController::Base
+  @trusted = false
+
+  before_action :set_trust
+  before_action :check_trust
+
+  def set_trust
+    @trusted = true
+  end
+
+  def check_trust
+    render :forbidden, text: "Trust check failed" unless @trusted
+  end
+end
+
+class FilterCheck < FilterOrdering
+  base "/filtering"
+  before_action :confirm_trust
+
+  def index
+    render text: "ok"
+  end
+
+  def confirm_trust
+    render :forbidden, text: "Trust confirmation failed" unless @trusted
+  end
+end
+
 # Testing ID params
 class Container < ActionController::Base
   id_param :container_id
+
+  @trusted = false
+
+  before_action :check_trust
+
+  def check_trust
+    @trusted = true
+  end
 
   def show
     render text: "got: #{params["container_id"]}"

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -36,14 +36,6 @@ end
 class Container < ActionController::Base
   id_param :container_id
 
-  @trusted = false
-
-  before_action :check_trust
-
-  def check_trust
-    @trusted = true
-  end
-
   def show
     render text: "got: #{params["container_id"]}"
   end

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -99,7 +99,8 @@ abstract class ActionController::Base
 
       macro __inherit_{{ltype.id}}_filters__
         \{% {{ftype.id}}_MAPPINGS[@type.name.id] = LOCAL_{{ftype.id}} %}
-        \{% klasses = [@type.name.id] + @type.ancestors %}
+        \{% klasses = [@type.name.id] %}
+        \{% @type.ancestors.each { |name| klasses.unshift(name) } %}
 
         # Create a mapping of all field names and types
         \{% for name in klasses %}


### PR DESCRIPTION
previous behaviour was to run the filters in the correct order per-class however it ran through the inheritance tree backwards.
This ensures the class order is correct AbstractBase -> Controller
previous behaviour was Controller -> AbstractBase