### PR TITLE
refactor(log_format): move message to before context and data

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: action-controller
-version: 4.1.0
+version: 4.2.0
 
 dependencies:
   # Used in clustering

--- a/src/action-controller/logger.cr
+++ b/src/action-controller/logger.cr
@@ -13,13 +13,12 @@ module ActionController
         str << "level=" << label << " time="
         timestamp.to_rfc3339(str)
         str << " source=" << entry.source
+        str << " message=\"" << entry.message << '"' unless entry.message.empty?
 
         # Add context tags
         {context, data}.each &.each do |k, v|
           str << " " << k << "=" << v
         end
-
-        str << " message=" << entry.message unless entry.message.empty?
 
         if exception = entry.exception
           str << "\n"


### PR DESCRIPTION
Move the message component of a log to before context and data.
This should improve the legibility of logs as the message will be aligned.