### PR TITLE
style: left justify severity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: crystal
 install:
-  - shards install
+  - shards install --ignore-crystal-version
 script:
   - crystal spec

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: action-controller
-version: 4.2.2
+version: 4.3.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/src/action-controller/logger.cr
+++ b/src/action-controller/logger.cr
@@ -10,7 +10,10 @@ module ActionController
       context = entry.context
       data = entry.data
       io << String.build do |str|
-        str << "level=" << label << " time="
+        str << "level="
+        # Left justify by length of "NOTICE", the longest `Log::Severity`
+        label.ljust(str, 6)
+        str << " time="
         timestamp.to_rfc3339(str)
         str << " source=" << entry.source
         str << " message=\"" << entry.message << '"' unless entry.message.empty?

--- a/src/action-controller/logger.cr
+++ b/src/action-controller/logger.cr
@@ -15,7 +15,7 @@ module ActionController
         label.ljust(str, 6)
         str << " time="
         timestamp.to_rfc3339(str)
-        str << " source=" << entry.source
+        str << " source=" << entry.source unless entry.source.empty?
         str << " message=\"" << entry.message << '"' unless entry.message.empty?
 
         # Add context tags

--- a/src/action-controller/responders.cr
+++ b/src/action-controller/responders.cr
@@ -85,6 +85,7 @@ module ActionController::Responders
   }
 
   macro render(status = :ok, head = Nop, json = Nop, yaml = Nop, xml = Nop, html = Nop, text = Nop, binary = Nop, template = Nop, partial = Nop, layout = nil)
+    # ameba:disable Style/IsAFilter
     {% if [head, json, xml, html, yaml, text, binary, template, partial].all?(&.is_a?(Path)) %}
       {{ raise "Render must be called with one of json, xml, html, yaml, text, binary, template, partial" }}
     {% end %}


### PR DESCRIPTION
This change ensures logs are aligned up to the `source` key.

Previously..

```
level=INFO time=2021-03-26T01:27:15Z source=some_class message="doing a thing"
level=DEBUG time=2021-03-26T01:27:15Z source=http.client message="Performing request"
level=NOTICE time=2021-03-26T01:28:15Z source=some_class message="Recovering from fault"
```

After this PR

```
level=INFO   time=2021-03-26T01:27:15Z source=some_class message="doing a thing"
level=DEBUG  time=2021-03-26T01:27:15Z source=http.client message="Performing request"
level=NOTICE time=2021-03-26T01:28:15Z source=some_class message="Recovering from fault"
```

Additionally, if `source` is empty, it is not formatted in the log.
