### PR TITLE
feat: render `progname` as `program` in default logger backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+on:
+  push:
+  schedule:
+    - cron: 0 0 * * 0 # Every Sunday at midnight
+jobs:
+  style:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: oprypin/install-crystal@v1
+        - uses: actions/checkout@v2
+        - name: Check Format
+          run: crystal tool format --check
+        - name: Check Lints
+          uses: crystal-ameba/github-action@v0.2.12
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  test:
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest]
+          crystal:
+            - nightly
+            - latest
+            - 1.0.0
+            - 0.36.1
+      runs-on: ${{ matrix.os }}
+      steps:
+        - uses: actions/checkout@v2
+        - name: Install Crystal
+          uses: oprypin/install-crystal@v1
+          with:
+            crystal: ${{ matrix.crystal }}
+        - name: Install Dependencies
+          run: shards install --ignore-crystal-version
+        - name: Run Specs
+          run: crystal spec -v --error-trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: crystal
-install:
-  - shards install --ignore-crystal-version
-script:
-  - crystal spec

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Spider-Gazelle Action Controller
 
-[![Build Status](https://travis-ci.org/spider-gazelle/action-controller.svg?branch=master)](https://travis-ci.org/spider-gazelle/action-controller)
+[![CI](https://github.com/spider-gazelle/action-controller/actions/workflows/ci.yml/badge.svg)](https://github.com/spider-gazelle/action-controller/actions/workflows/ci.yml)
 
-Extending [router.cr](https://github.com/tbrand/router.cr) for a Rails like DSL without the overhead.
-
+Extending [lucky_router](https://github.com/luckyframework/lucky_router) for a Rails like DSL without the overhead.
 
 ## Usage
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: action-controller
-version: 4.3.6
-crystal: ~> 1.0
+version: 4.4.0
+crystal: ">= 0.36.1, ~> 1.0"
 
 dependencies:
   # Used in clustering

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -22,7 +22,7 @@ abstract class ActionController::Base
   {% TEMPLATE_PATH[@type.id] = "./src/views/" %}
 
   macro layout(filename = nil)
-    {% if filename.nil? || filename.empty? %}
+    {% if filename == nil || filename.empty? %}
       {% TEMPLATE_LAYOUT[@type.id] = nil %}
     {% else %}
       {% TEMPLATE_LAYOUT[@type.id] = filename %}
@@ -551,7 +551,7 @@ abstract class ActionController::Base
   end
 
   macro base(name = nil)
-    {% if name.nil? || name.empty? || name == "/" %}
+    {% if name == nil || name.empty? || name == "/" %}
       {% NAMESPACE[0] = "/" %}
     {% else %}
       {% if name.id.stringify.starts_with?("/") %}

--- a/src/action-controller/logger.cr
+++ b/src/action-controller/logger.cr
@@ -15,6 +15,7 @@ module ActionController
         label.ljust(str, 6)
         str << " time="
         timestamp.to_rfc3339(str)
+        str << " program=" << entry.progname unless entry.progname.empty?
         str << " source=" << entry.source unless entry.source.empty?
         str << " message=\"" << entry.message << '"' unless entry.message.empty?
 
@@ -47,7 +48,9 @@ module ActionController
     ::Log::Formatter.new do |entry, io|
       # typeof doesn't execute anything
       json = {} of String => typeof(log_metadata_to_raw(entry.data[:check]))
+
       json["level"] = entry.severity.label
+      json["program"] = entry.progname unless entry.progname.empty?
       json["time"] = entry.timestamp
       json["source"] = entry.source
       json["message"] = entry.message unless entry.message.empty?

--- a/src/action-controller/responders.cr
+++ b/src/action-controller/responders.cr
@@ -85,7 +85,6 @@ module ActionController::Responders
   }
 
   macro render(status = :ok, head = Nop, json = Nop, yaml = Nop, xml = Nop, html = Nop, text = Nop, binary = Nop, template = Nop, partial = Nop, layout = nil)
-    # ameba:disable Style/IsAFilter
     {% if [head, json, xml, html, yaml, text, binary, template, partial].all?(&.is_a?(Path)) %}
       {{ raise "Render must be called with one of json, xml, html, yaml, text, binary, template, partial" }}
     {% end %}


### PR DESCRIPTION
Renders the `progname` property of the logger as `program` in the JSON and IO based log backend

- Adds github CI, Closes #43
- Fixes #44