### PR TITLE
feat: forward annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,37 @@
 name: CI
 on:
   push:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1"
 jobs:
-  build:
+  style:
+  runs-on: ubuntu-latest
+  container:
+    image: crystallang/crystal
+  steps:
+    - uses: actions/checkout@v2
+    - name: Format
+      run: crystal tool format --check
+    - name: Lint
+      uses: crystal-ameba/github-action@v0.2.12
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         crystal:
           - latest
           - nightly
           - 1.0.0
-    runs-on: ${{ matrix.os }}
-    container: crystallang/crystal:${{ matrix.crystal }}-alpine
+    runs-on: ubuntu-latest
+    container: crystallang/crystal:${{ matrix.crystal }}
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: shards install --ignore-crystal-version
-    - name: Lint
-      run: ./bin/ameba
-    - name: Format
-      run: crystal tool format --check
-    - name: Run tests
+    - name: Tests
       run: crystal spec -v --error-trace
+    - name: Tests Multithreaded
+      run: crystal spec -Dpreview_mt -v --error-trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - latest
           - nightly
           - 1.0.0
+          - 0.36.1
     runs-on: ubuntu-latest
     container: crystallang/crystal:${{ matrix.crystal }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
-docs
-lib
+.DS_Store
 .crystal
 .shards
 bin
-.DS_Store
-
-# Libraries don't need dependency lock
-# Dependencies will be locked in application that uses them
+docs
+lib
 shard.lock

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,8 @@
 name: action-controller
-version: 4.4.1
-crystal: ">= 0.36.1, ~> 1.0"
+version: 4.5.0
+crystal: ">= 0.36.1"
 
 dependencies:
-  # Used in clustering
   future:
     github: crystal-community/future.cr
     version: ~> 1.0
@@ -22,7 +21,7 @@ development_dependencies:
 
 authors:
   - Stephen von Takach <steve@place.tech>
-  - Caspian Baska <caspian@place.tech>
+  - Caspian Baska <email@caspian.computer>
   - Kim Burgess <kim@place.tech>
   - Duke Nguyen <duke@place.tech>
 

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -43,4 +43,14 @@ describe ActionController::Base do
     result = curl("GET", "/filtering")
     result.body.should eq("ok")
   end
+
+  describe "route annotations" do
+    it "can be a single annotation" do
+      curl("GET", "/hello/annotation/single").body.should eq %([@[ActionController::TestAnnotation(detail: "single")]])
+    end
+
+    it "can be an array of annotations" do
+      curl("GET", "/hello/annotation/multi").body.should eq %([@[ActionController::TestAnnotation], @[ActionController::TestAnnotation]])
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -163,6 +163,11 @@ class Users < ActionController::Base
   end
 end
 
+module ActionController
+  annotation TestAnnotation
+  end
+end
+
 class HelloWorld < Application
   base "/hello"
 
@@ -192,6 +197,14 @@ class HelloWorld < Application
         XML.parse(str)
       end
     end
+  end
+
+  get "/annotation/single", :single_annotation, annotations: @[ActionController::TestAnnotation(detail: "single")] do
+    render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
+  end
+
+  get "/annotation/multi", :multi_annotation, annotations: [@[ActionController::TestAnnotation], @[ActionController::TestAnnotation]] do
+    render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
   end
 
   get "/around", :around do

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -150,21 +150,9 @@ abstract class ActionController::Base
     @__cookies__ = HTTP::Cookies.new
   end
 
-  macro request
-    @context.request
-  end
+  delegate request, response, route_params, to: @context
 
-  macro response
-    @context.response
-  end
-
-  macro route_params
-    @context.route_params
-  end
-
-  macro query_params
-    @context.request.query_params
-  end
+  delegate query_params, to: @context.request
 
   getter params : URI::Params do
     _params = ActionController::Base.extract_params(@context)
@@ -293,9 +281,9 @@ abstract class ActionController::Base
       {% end %}
 
       # Helper for obtaining base route
-      getter base_route = {{NAMESPACE[0]}}
-      # :ditto:
       class_getter base_route = {{NAMESPACE[0]}}
+      # :ditto:
+      delegate base_route, to: self.class
     {% end %}
   end
 

--- a/src/action-controller/logger.cr
+++ b/src/action-controller/logger.cr
@@ -10,14 +10,12 @@ module ActionController
       context = entry.context
       data = entry.data
       io << String.build do |str|
-        str << "["
-        str << label
-        str << "]"
+        str << "level=[" << label << "]"
         str << " time="
         timestamp.to_rfc3339(str)
         str << " program=" << ::Log.progname unless ::Log.progname.empty?
         str << " source=" << entry.source unless entry.source.empty?
-        str << " message=\"" << entry.message << '"' unless entry.message.empty?
+        str << %( message=") << entry.message << '"' unless entry.message.empty?
 
         # Add context tags
         {context, data}.each &.each do |k, v|


### PR DESCRIPTION
Simplifies the usage of annotations on routes.
Now you can pass annotations to a route as below.

```crystal
...

annotation Test
end

get "/annotation/single", :single_annotation, annotations: @[Test(detail: "single")] do
  render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
end

get "/annotation/multi", :multi_annotation, annotations: [@[Test], @[Test(detail: "multi"]] do
  render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
end

...
```

*Included in this PR*

- Fixup the version matrix in CI
- Add tests for multithreading (use the ubuntu crystal image, as alpine does not support multithreading)
- Use the ameba action in CI
- Tidy up `base.cr` with the use of the `delegate` macro
- A few clarifications to comments
- Fix the log formatter to show the `level` key before rendering the level, in line with other log metadata