### PR TITLE
Inline annotations

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -52,5 +52,9 @@ describe ActionController::Base do
     it "can be an array of annotations" do
       curl("GET", "/hello/annotation/multi").body.should eq %([@[ActionController::TestAnnotation], @[ActionController::TestAnnotation]])
     end
+
+    it "forward annotations when specified inline" do
+      curl("GET", "/hello/annotation/inline").body.should eq %([@[ActionController::TestAnnotation(test: "inline")]])
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -207,6 +207,11 @@ class HelloWorld < Application
     render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
   end
 
+  @[ActionController::TestAnnotation(test: "inline")]
+  get "/annotation/inline" do
+    render text: {{ @def.annotations(ActionController::TestAnnotation).id.stringify }}
+  end
+
   get "/around", :around do
     render text: "var is #{@me}"
   end

--- a/src/action-controller/base.cr
+++ b/src/action-controller/base.cr
@@ -274,6 +274,9 @@ abstract class ActionController::Base
               {{ ann.id }}
             {% end %}
           {% end %}
+          \{% for ann in ANN__{{name.id}}.annotations(ActionController::TestAnnotation) %}
+            \{{ ann.id }}
+          \{% end %}
           def {{name}}({{*block.args}})
             {{block.body}}
           end
@@ -567,6 +570,7 @@ abstract class ActionController::Base
       \{% unless name %}
         \{% name = {{http_method}} + path.gsub(/\/|\-|\~|\*|\:|\./, "_") %}
       \{% end %}
+      private struct ANN__\{{name.id}}; end
       \{% LOCAL_ROUTES[name.id] = { {{http_method}}, path, annotations, block, false } %}
     end
   {% end %}
@@ -575,6 +579,7 @@ abstract class ActionController::Base
     {% unless name %}
       {% name = "ws" + path.gsub(/\/|\-|\~|\*|\:|\./, "_") %}
     {% end %}
+    private struct ANN__{{name.id}}; end
     {% LOCAL_ROUTES[name.id] = {"get", path, annotations, block, true} %}
   end
 


### PR DESCRIPTION
Add supports for normal annotation semantics when marking up routes defined by macros.

```crystal
@[ActionController::TestAnnotation(test: "inline")]
get "/example" do
  # ...
end
```

Annotation a captured onto a throwaway type, then re-applied to the appropriate method when routes are drawn. As the original types are unused these will be dropped by the compiler.

Currently a limitation exists where the types of annotation need to be explicitly specified, however will continue searching for a solution to this. Until that is resolved, treat this as a proof of concept only.