### PR TITLE
feat(router): add controller method to log context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,34 +5,41 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 jobs:
-  style:
-    runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
-    steps:
-      - uses: actions/checkout@v2
-      - name: Format
-        run: crystal tool format --check
-      - name: Lint
-        uses: crystal-ameba/github-action@v0.2.12
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  crystal-style:
+    name: Crystal Style
+    uses: PlaceOS/.github/.github/workflows/crystal-style.yml@main
+
   test:
+    name: "${{ !matrix.stable && '🚧 ' || '' }}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT && '☑' || '☐' }}"
     strategy:
       fail-fast: false
       matrix:
+        MT: [true, false]
+        stable: [true]
         crystal:
-          - latest
-          - nightly
           - 1.2.2
+          - latest
+        include:
+          - crystal: nightly
+            MT: true
+            stable: false
+          - crystal: nightly
+            MT: false
+            stable: false
     runs-on: ubuntu-latest
-    container: crystallang/crystal:${{ matrix.crystal }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install --ignore-crystal-version
-    - name: Tests
-      run: crystal spec -v --error-trace
-    - name: Tests Multithreaded
-      run: crystal spec -Dpreview_mt -v --error-trace
-      if: ${{ matrix.crystal != '0.36.1' }} # MT not supported for crystal v0.36.1
+      - uses: actions/checkout@v2
+      - name: Install crystal
+        uses: crystal-lang/install-crystal@v1.5.3
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Install dependencies
+        run: shards install --ignore-crystal-version
+      - name: Test ${{ matrix.MT && 'Multithreaded' || '' }}
+        run: |
+          crystal spec \
+          --error-trace \
+          ${{ matrix.MT && '-Dpreview_mt' || '' }} \
+          --order random \
+          --verbose

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: action-controller
-version: 4.6.0
+version: 4.7.0
 crystal: ">= 1.2.2"
 
 dependencies:

--- a/src/action-controller/router/route_handler.cr
+++ b/src/action-controller/router/route_handler.cr
@@ -26,6 +26,8 @@ class ActionController::Router::RouteHandler
   # Called from HTTP::Server in server.cr
   def call(context : HTTP::Server::Context)
     if action = search_route(context)
+      # Set the controller name
+      ::Log.context.set(controller_method: action[1])
       action[0].call(context, action[1])
     else
       # defined in https://crystal-lang.org/api/latest/HTTP/Handler.html

--- a/src/action-controller/router/server_context.cr
+++ b/src/action-controller/router/server_context.cr
@@ -2,10 +2,7 @@ require "http/server"
 
 # Adds a helper method for storing params extracted from radix tree routes
 class HTTP::Server::Context
-  @route_params : Hash(String, String)?
-  setter route_params
-
-  def route_params : Hash(String, String)
-    @route_params || {} of String => String
+  property route_params : Hash(String, String) do
+    {} of String => String
   end
 end


### PR DESCRIPTION
Small feature request by @camreeves

Adds `controller_method` to the log context when a route is matched.

Additionally includes a minor refactor for the extended HTTP context.