### PR TITLE
Show `accepts_formats` in Exception for debugging

### DIFF
--- a/src/action-controller/router/builder.cr
+++ b/src/action-controller/router/builder.cr
@@ -196,7 +196,7 @@ module ActionController::Route::Builder
                   responds_with = {{content_type}}
                 {% else %}
                   responds_with = accepts_formats.first? || {{ DEFAULT_RESPONDER[0] }}
-                  raise AC::Route::NotAcceptable.new("no renderer available for #{responds_with}, have #{accepts_formats}", {{@type.name.id}}.accepts) unless {{@type.name.id}}.can_respond_with?(responds_with)
+                  raise AC::Route::NotAcceptable.new("no renderer available for #{RESPONDER_LIST}, have #{accepts_formats}", {{@type.name.id}}.accepts) unless {{@type.name.id}}.can_respond_with?(responds_with)
                 {% end %}
             {% end %}
           {% end %}

--- a/src/action-controller/router/builder.cr
+++ b/src/action-controller/router/builder.cr
@@ -196,7 +196,7 @@ module ActionController::Route::Builder
                   responds_with = {{content_type}}
                 {% else %}
                   responds_with = accepts_formats.first? || {{ DEFAULT_RESPONDER[0] }}
-                  raise AC::Route::NotAcceptable.new("no renderer available for #{responds_with}", {{@type.name.id}}.accepts) unless {{@type.name.id}}.can_respond_with?(responds_with)
+                  raise AC::Route::NotAcceptable.new("no renderer available for #{responds_with}, have #{accepts_formats}", {{@type.name.id}}.accepts) unless {{@type.name.id}}.can_respond_with?(responds_with)
                 {% end %}
             {% end %}
           {% end %}


### PR DESCRIPTION
This is more of a bug report than a PR.  Feel free to close instead of merge.

`respond_with` doesn't add a handler for `html` or I screwed up.

`curl -v -F a=b -H 'Accept: text/html' http://127.0.0.1:3000/`

Results:
`ERROR: no renderer available for text/html, have ["application/json"] (ActionController::Route::NotAcceptable)`

```crystal
@[AC::Route::POST("/")]
def create
  respond_with do
    html do
       uri = ...
       redirect_to uri
    end
    json do
      ...
    end
end
```
