### PR TITLE
Addition of HTTPS support

### DIFF
--- a/src/action-controller/router/route_params.cr
+++ b/src/action-controller/router/route_params.cr
@@ -86,6 +86,13 @@ module ActionController::Route::Param
   end
 
   # :nodoc:
+  struct ConvertUUID < Conversion
+    def convert(raw : String)
+      UUID.parse?(raw)
+    end
+  end
+
+  # :nodoc:
   struct ConvertEnum(T)
     def self.convert(raw : String)
       value = raw.to_i64? || raw

--- a/src/action-controller/router/route_params.cr
+++ b/src/action-controller/router/route_params.cr
@@ -86,13 +86,6 @@ module ActionController::Route::Param
   end
 
   # :nodoc:
-  struct ConvertUUID < Conversion
-    def convert(raw : String)
-      UUID.parse?(raw)
-    end
-  end
-
-  # :nodoc:
   struct ConvertEnum(T)
     def self.convert(raw : String)
       value = raw.to_i64? || raw

--- a/src/action-controller/server.cr
+++ b/src/action-controller/server.cr
@@ -78,8 +78,8 @@ class ActionController::Server
   # Starts the server
   def run
     if @socket.addresses.empty?
-      if @ssl_context
-        @socket.bind_tls(@host, @port, @ssl_context.not_nil!, @reuse_port)
+      if ssl_context = @ssl_context
+        @socket.bind_tls(@host, @port, ssl_context, @reuse_port)
       else
         @socket.bind_tcp(@host, @port, @reuse_port) 
       end

--- a/src/action-controller/server.cr
+++ b/src/action-controller/server.cr
@@ -66,7 +66,7 @@ class ActionController::Server
   def run(&)
     if @socket.addresses.empty?
       if @ssl_context
-        @socket.bind_tls(@host, @port, @ssl_context, @reuse_port)
+        @socket.bind_tls(@host, @port, @ssl_context.not_nil!, @reuse_port)
       else
         @socket.bind_tcp(@host, @port, @reuse_port) 
       end
@@ -79,7 +79,7 @@ class ActionController::Server
   def run
     if @socket.addresses.empty?
       if @ssl_context
-        @socket.bind_tls(@host, @port, @ssl_context, @reuse_port)
+        @socket.bind_tls(@host, @port, @ssl_context.not_nil!, @reuse_port)
       else
         @socket.bind_tcp(@host, @port, @reuse_port) 
       end

--- a/src/action-controller/server.cr
+++ b/src/action-controller/server.cr
@@ -65,8 +65,8 @@ class ActionController::Server
   # Starts the server, providing a callback once the ports are bound
   def run(&)
     if @socket.addresses.empty?
-      if @ssl_context
-        @socket.bind_tls(@host, @port, @ssl_context.not_nil!, @reuse_port)
+      if ssl_context = @ssl_context
+        @socket.bind_tls(@host, @port, ssl_context, @reuse_port)
       else
         @socket.bind_tcp(@host, @port, @reuse_port) 
       end


### PR DESCRIPTION
New init overload that accepts a ssl context (OpenSSL::SSL::Context::Server class type). When the server is started it uses #bind_tls instead of #bind_tcp. HTTP can still be used, if you dont provide the ssl context.

Example:
```cr
ssl_context = OpenSSL::SSL::Context::Server.new
ssl_context.certificate_chain= "example.crt"
ssl_context.private_key= "example.key"

server = ActionController::Server.new(ssl_context, "0.0.0.0", 5000)

server.run()
```

