### PR TITLE
Bump `exception_page` shard to v0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ dependencies:
     version: ~> 0.5
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.3
+    version: ~> 0.4
 
   # Required for running specs in client apps
   hot_topic:


### PR DESCRIPTION
### Description of the Change

Bumps `exception_page` shard version to `~> 0.4.0`, which includes syntax highlighting and tweaked UX.